### PR TITLE
Pan os pr batch 1

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -15491,7 +15491,7 @@ def main():  # pragma: no cover
             panorama_download_latest_dynamic_update_command(DynamicUpdateType.GP, args)
 
         # Check download status of the latest app/threat content update
-        elif command == "pan-os-content-update-download-status":
+        elif command == "panorama-content-update-download-status" or command == "pan-os-content-update-download-status":
             panorama_dynamic_update_download_status_command(DynamicUpdateType.APP_THREAT, args)
 
         # Check download status of the latest antivirus content update

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -9604,6 +9604,7 @@ class ShowSystemInfoResultData(ResultData):
     :param wildfire_version: Wildfire content version
     :param wildfire_release_date: Wildfire release date
     :param url_filtering_version: URL Filtering content version
+    :param global_protect_client_package_version: GlobalProtect content version
     """
 
     ip_address: str
@@ -9628,6 +9629,7 @@ class ShowSystemInfoResultData(ResultData):
     wildfire_version: str = "not_installed"
     wildfire_release_date: str = "not_installed"
     url_filtering_version: str = "not_installed"
+    global_protect_client_package_version: str = "0.0.0"
 
 
 @dataclass

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -7888,6 +7888,9 @@ script:
     - contextPath: PANOS.ShowSystemInfo.Result.url_filtering_version
       description: The URL filtering content version.
       type: String
+    - contextPath: PANOS.ShowSystemInfo.Result.global_protect_client_package_version
+      description: The GlobalProtect client package version.
+      type: String
   - arguments:
     - description: The string by which to filter the results to only show specific hostnames or serial numbers.
       name: device_filter_string

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -5749,6 +5749,7 @@ Gets information from all PAN-OS systems in the topology.
 | PANOS.ShowSystemInfo.Result.wildfire_version | String | Wildfire content version. |
 | PANOS.ShowSystemInfo.Result.wildfire_release_date | String | Wildfire release date. |
 | PANOS.ShowSystemInfo.Result.url_filtering_version | String | URL filtering content version. |
+| PANOS.ShowSystemInfo.Result.global_protect_client_package_version | String | The GlobalProtect client package version. |
 
 #### Command example
 
@@ -5783,7 +5784,8 @@ Gets information from all PAN-OS systems in the topology.
                     "uptime": "22 days, 0:20:49",
                     "url_filtering_version": "20220218.20012",
                     "wildfire_release_date": "",
-                    "wildfire_version": "0"
+                    "wildfire_version": "0",
+                    "global_protect_client_package_version": "0.0.0"
                 },
                 {
                     "app_release_date": "2021/12/06 18:49:44 PST",


### PR DESCRIPTION
## Description
1. Updated the pan-os-platform-get-system-info command to show the "global_protect_client_package_version" in it's output. Updated the yml and README for this change as well.
2. Added the "panorama-content-update-download-status" alias back to the pan-os-content-update-download-status command.